### PR TITLE
Add Airflow DAGs — Bronze→Silver, Silver→Gold, full pipeline

### DIFF
--- a/airflow_dags/dag_bronze_to_silver.py
+++ b/airflow_dags/dag_bronze_to_silver.py
@@ -1,0 +1,61 @@
+"""
+Airflow DAG: Bronze → Silver (maintenance role in Kappa architecture)
+======================================================================
+In Kappa, Airflow is the JANITOR, not the conductor. The continuous Spark
+Structured Streaming pipeline handles the main ETL. Airflow handles:
+  - Daily EHR batch ingestion (batch files → Silver via ehr_silver.py)
+  - Identity resolution refresh
+  - Pharmacy CDC backfill
+
+Schedule: daily at 2AM for EHR. Manual trigger for dev.
+"""
+from datetime import datetime, timedelta
+from airflow import DAG
+from airflow.operators.bash import BashOperator
+
+PULSETRACK_DIR = "/opt/airflow/pulsetrack"
+
+default_args = {
+    "owner":           "pulsetrack",
+    "retries":         1,
+    "retry_delay":     timedelta(minutes=5),
+    "email_on_failure": False,
+}
+
+with DAG(
+    dag_id="pulsetrack_bronze_to_silver",
+    default_args=default_args,
+    description="PulseTrack: Batch sources → Silver (EHR, pharmacy, identity)",
+    schedule_interval="0 2 * * *",
+    start_date=datetime(2024, 1, 1),
+    catchup=False,
+    tags=["pulsetrack", "silver", "kappa-maintenance"],
+) as dag:
+
+    ehr_silver = BashOperator(
+        task_id="ehr_silver",
+        bash_command=f"cd {PULSETRACK_DIR} && python transformations/bronze_to_silver/ehr_silver.py",
+        doc_md="Parse EHR FHIR batches → silver/ehr_conditions, ehr_medications, ehr_lab_results",
+    )
+
+    pharmacy_bronze = BashOperator(
+        task_id="pharmacy_bronze",
+        bash_command=f"cd {PULSETRACK_DIR} && python batch_ingestion/pharmacy_bronze.py",
+        doc_md="Drain pharmacy_events Kafka topic → bronze/pharmacy/",
+    )
+
+    pharmacy_silver = BashOperator(
+        task_id="pharmacy_silver",
+        bash_command=f"cd {PULSETRACK_DIR} && python transformations/bronze_to_silver/pharmacy_silver.py",
+        doc_md="CDC upsert bronze/pharmacy → silver/pharmacy_prescriptions",
+    )
+
+    identity_bridge = BashOperator(
+        task_id="identity_bridge",
+        bash_command=f"cd {PULSETRACK_DIR} && python transformations/identity_resolution/patient_identity_bridge.py",
+        doc_md="Refresh patient_identity_bridge — links EHR MRNs to device accounts",
+    )
+
+    # EHR and pharmacy run in parallel, both feed identity bridge
+    [ehr_silver, pharmacy_silver] >> identity_bridge
+    pharmacy_bronze >> pharmacy_silver

--- a/airflow_dags/dag_full_pipeline.py
+++ b/airflow_dags/dag_full_pipeline.py
@@ -1,0 +1,142 @@
+"""
+Airflow DAG: Full Pipeline Orchestrator
+========================================
+Master DAG that chains Bronze → Silver → Gold end-to-end.
+Triggers dag_bronze_to_silver first (batch maintenance), then
+dag_silver_to_gold (dimensional build) after all Silver jobs confirm.
+
+Architecture note (Kappa):
+  This DAG is the JANITOR coordinator, not the conductor. The continuous
+  Spark Structured Streaming pipeline is the real ETL engine. This DAG
+  handles the batch maintenance sequence:
+    1. EHR ingestion + pharmacy backfill (Silver layer)
+    2. Identity resolution refresh
+    3. Full Gold rebuild from refreshed Silver
+    4. Post-build health check
+
+Schedule: Manual trigger (run after deploying schema changes or
+          after a full Silver rebuild is needed).
+"""
+from datetime import datetime, timedelta
+from airflow import DAG
+from airflow.operators.bash import BashOperator
+from airflow.operators.trigger_dagrun import TriggerDagRunOperator
+from airflow.sensors.external_task import ExternalTaskSensor
+
+PULSETRACK_DIR = "/opt/airflow/pulsetrack"
+BASE = f"cd {PULSETRACK_DIR} && python"
+
+default_args = {
+    "owner":            "pulsetrack",
+    "retries":          1,
+    "retry_delay":      timedelta(minutes=5),
+    "email_on_failure": False,
+}
+
+with DAG(
+    dag_id="pulsetrack_full_pipeline",
+    default_args=default_args,
+    description="PulseTrack: Full Bronze → Silver → Gold pipeline (batch maintenance)",
+    schedule_interval=None,
+    start_date=datetime(2024, 1, 1),
+    catchup=False,
+    tags=["pulsetrack", "orchestrator", "kappa-maintenance"],
+) as dag:
+
+    # ── Stage 1: Batch Silver maintenance ───────────────────────────────
+    ehr_silver = BashOperator(
+        task_id="ehr_silver",
+        bash_command=f"{BASE} transformations/bronze_to_silver/ehr_silver.py",
+        doc_md="Parse EHR FHIR batches → silver/ehr_conditions, ehr_medications, ehr_lab_results",
+    )
+
+    pharmacy_bronze = BashOperator(
+        task_id="pharmacy_bronze",
+        bash_command=f"{BASE} batch_ingestion/pharmacy_bronze.py",
+        doc_md="Drain pharmacy_events Kafka topic → bronze/pharmacy/",
+    )
+
+    pharmacy_silver = BashOperator(
+        task_id="pharmacy_silver",
+        bash_command=f"{BASE} transformations/bronze_to_silver/pharmacy_silver.py",
+        doc_md="CDC upsert bronze/pharmacy → silver/pharmacy_prescriptions",
+    )
+
+    identity_bridge = BashOperator(
+        task_id="identity_bridge",
+        bash_command=f"{BASE} transformations/identity_resolution/patient_identity_bridge.py",
+        doc_md="Refresh patient_identity_bridge — links EHR MRNs + device accounts",
+    )
+
+    # ── Stage 2: Gold Wave 1 — Reference dims ───────────────────────────
+    dim_date = BashOperator(task_id="dim_date",
+        bash_command=f"{BASE} transformations/silver_to_gold/dim_date.py")
+    dim_time = BashOperator(task_id="dim_time",
+        bash_command=f"{BASE} transformations/silver_to_gold/dim_time.py")
+    dim_condition_category = BashOperator(task_id="dim_condition_category",
+        bash_command=f"{BASE} transformations/silver_to_gold/dim_condition_category.py")
+    dim_drug_class = BashOperator(task_id="dim_drug_class",
+        bash_command=f"{BASE} transformations/silver_to_gold/dim_drug_class.py")
+    dim_metric = BashOperator(task_id="dim_metric",
+        bash_command=f"{BASE} transformations/silver_to_gold/dim_metric.py")
+
+    # ── Stage 2: Gold Wave 2 — Entity dim ───────────────────────────────
+    dim_patient = BashOperator(task_id="dim_patient",
+        bash_command=f"{BASE} transformations/silver_to_gold/dim_patient.py")
+
+    # ── Stage 2: Gold Wave 3 — Snowflaked entity dims ───────────────────
+    dim_condition = BashOperator(task_id="dim_condition",
+        bash_command=f"{BASE} transformations/silver_to_gold/dim_condition.py")
+    dim_medication = BashOperator(task_id="dim_medication",
+        bash_command=f"{BASE} transformations/silver_to_gold/dim_medication.py")
+    dim_device = BashOperator(task_id="dim_device",
+        bash_command=f"{BASE} transformations/silver_to_gold/dim_device.py")
+
+    # ── Stage 2: Gold Wave 4 — Facts ────────────────────────────────────
+    fact_vital_reading = BashOperator(task_id="fact_vital_reading",
+        bash_command=f"{BASE} transformations/silver_to_gold/fact_vital_reading.py")
+    fact_vital_daily = BashOperator(task_id="fact_vital_daily_summary",
+        bash_command=f"{BASE} transformations/silver_to_gold/fact_vital_daily_summary.py")
+    fact_lab = BashOperator(task_id="fact_lab_result",
+        bash_command=f"{BASE} transformations/silver_to_gold/fact_lab_result.py")
+    fact_rx = BashOperator(task_id="fact_prescription_fill",
+        bash_command=f"{BASE} transformations/silver_to_gold/fact_prescription_fill.py")
+    anomaly = BashOperator(task_id="anomaly_detector",
+        bash_command=f"{BASE} streaming/anomaly_detector.py")
+
+    # ── Stage 3: Post-build validation ──────────────────────────────────
+    health_check = BashOperator(
+        task_id="pipeline_health_check",
+        bash_command=f"{BASE} monitoring/pipeline_health_check.py",
+        doc_md="FK integrity, row counts, HIPAA scan, identity coverage",
+    )
+
+    scd2_audit = BashOperator(
+        task_id="scd2_audit",
+        bash_command=f"{BASE} monitoring/scd2_audit.py",
+        doc_md="SCD2 chain integrity: no gaps/overlaps in effective_date ranges",
+    )
+
+    # ── Dependencies: Silver maintenance ────────────────────────────────
+    [ehr_silver, pharmacy_silver] >> identity_bridge
+    pharmacy_bronze >> pharmacy_silver
+
+    # ── Dependencies: Silver → Gold (all Silver must finish first) ──────
+    wave1 = [dim_date, dim_time, dim_condition_category, dim_drug_class, dim_metric]
+    identity_bridge >> wave1
+
+    wave1 >> dim_patient
+
+    dim_condition_category >> dim_condition
+    dim_drug_class         >> dim_medication
+    dim_patient >> [dim_condition, dim_medication, dim_device]
+
+    dim_device  >> fact_vital_reading
+    dim_metric  >> [fact_vital_reading, fact_vital_daily, anomaly]
+    dim_patient >> [fact_vital_reading, fact_vital_daily, fact_lab, fact_rx, anomaly]
+    dim_condition  >> fact_lab
+    dim_medication >> fact_rx
+
+    # ── Dependencies: Post-build checks ─────────────────────────────────
+    facts = [fact_vital_reading, fact_vital_daily, fact_lab, fact_rx, anomaly]
+    facts >> [health_check, scd2_audit]

--- a/airflow_dags/dag_silver_to_gold.py
+++ b/airflow_dags/dag_silver_to_gold.py
@@ -1,0 +1,97 @@
+"""
+Airflow DAG: Silver → Gold (Snowflake Schema build)
+======================================================
+Dependency order (Snowflake Schema enforces FK order):
+
+  Wave 1 — Reference dims (no upstream deps, parallel):
+    dim_date, dim_time, dim_condition_category, dim_drug_class, dim_metric
+
+  Wave 2 — Entity dim (needs identity bridge):
+    dim_patient
+
+  Wave 3 — Snowflaked entity dims (need dim_patient + FK reference dims):
+    dim_condition (→ dim_condition_category)
+    dim_medication (→ dim_drug_class)
+    dim_device     (→ dim_patient)
+
+  Wave 4 — Facts (need all dims):
+    fact_vital_reading        (→ dim_patient, dim_device, dim_metric)
+    fact_vital_daily_summary  (→ dim_patient, dim_metric)
+    fact_lab_result           (→ dim_patient, dim_condition)
+    fact_prescription_fill    (→ dim_patient, dim_medication)
+    anomaly_detector          (→ dim_patient, dim_metric)
+"""
+from datetime import datetime, timedelta
+from airflow import DAG
+from airflow.operators.bash import BashOperator
+
+PULSETRACK_DIR = "/opt/airflow/pulsetrack"
+BASE = f"cd {PULSETRACK_DIR} && python"
+
+default_args = {
+    "owner":           "pulsetrack",
+    "retries":         1,
+    "retry_delay":     timedelta(minutes=5),
+    "email_on_failure": False,
+}
+
+with DAG(
+    dag_id="pulsetrack_silver_to_gold",
+    default_args=default_args,
+    description="PulseTrack: Silver → Gold Snowflake Schema",
+    schedule_interval=None,
+    start_date=datetime(2024, 1, 1),
+    catchup=False,
+    tags=["pulsetrack", "gold", "snowflake"],
+) as dag:
+
+    # ── Wave 1: Reference dimensions ────────────────────────────────────
+    dim_date = BashOperator(task_id="dim_date",
+        bash_command=f"{BASE} transformations/silver_to_gold/dim_date.py")
+    dim_time = BashOperator(task_id="dim_time",
+        bash_command=f"{BASE} transformations/silver_to_gold/dim_time.py")
+    dim_condition_category = BashOperator(task_id="dim_condition_category",
+        bash_command=f"{BASE} transformations/silver_to_gold/dim_condition_category.py")
+    dim_drug_class = BashOperator(task_id="dim_drug_class",
+        bash_command=f"{BASE} transformations/silver_to_gold/dim_drug_class.py")
+    dim_metric = BashOperator(task_id="dim_metric",
+        bash_command=f"{BASE} transformations/silver_to_gold/dim_metric.py")
+
+    # ── Wave 2: dim_patient ─────────────────────────────────────────────
+    dim_patient = BashOperator(task_id="dim_patient",
+        bash_command=f"{BASE} transformations/silver_to_gold/dim_patient.py")
+
+    # ── Wave 3: Snowflaked entity dimensions ────────────────────────────
+    dim_condition = BashOperator(task_id="dim_condition",
+        bash_command=f"{BASE} transformations/silver_to_gold/dim_condition.py")
+    dim_medication = BashOperator(task_id="dim_medication",
+        bash_command=f"{BASE} transformations/silver_to_gold/dim_medication.py")
+    dim_device = BashOperator(task_id="dim_device",
+        bash_command=f"{BASE} transformations/silver_to_gold/dim_device.py")
+
+    # ── Wave 4: Fact tables ─────────────────────────────────────────────
+    fact_vital_reading = BashOperator(task_id="fact_vital_reading",
+        bash_command=f"{BASE} transformations/silver_to_gold/fact_vital_reading.py")
+    fact_vital_daily = BashOperator(task_id="fact_vital_daily_summary",
+        bash_command=f"{BASE} transformations/silver_to_gold/fact_vital_daily_summary.py")
+    fact_lab = BashOperator(task_id="fact_lab_result",
+        bash_command=f"{BASE} transformations/silver_to_gold/fact_lab_result.py")
+    fact_rx = BashOperator(task_id="fact_prescription_fill",
+        bash_command=f"{BASE} transformations/silver_to_gold/fact_prescription_fill.py")
+    anomaly = BashOperator(task_id="anomaly_detector",
+        bash_command=f"{BASE} streaming/anomaly_detector.py")
+
+    # ── Dependencies ────────────────────────────────────────────────────
+    wave1 = [dim_date, dim_time, dim_condition_category, dim_drug_class, dim_metric]
+
+    wave1 >> dim_patient
+
+    dim_condition_category >> dim_condition
+    dim_drug_class         >> dim_medication
+    dim_patient >> [dim_condition, dim_medication, dim_device]
+
+    dim_device  >> fact_vital_reading
+    dim_metric  >> [fact_vital_reading, fact_vital_daily, anomaly]
+    dim_patient >> [fact_vital_reading, fact_vital_daily, fact_lab, fact_rx, anomaly]
+    dim_condition  >> fact_lab
+    dim_medication >> fact_rx


### PR DESCRIPTION
## Summary
Three DAGs implementing Kappa maintenance orchestration (Airflow as JANITOR, not conductor):

- `dag_bronze_to_silver` (daily 2AM): EHR + pharmacy batch ingestion → identity bridge refresh
- `dag_silver_to_gold` (manual): 4-wave Gold rebuild respecting Snowflake FK dependency order
- `dag_full_pipeline` (manual): chains both above DAGs end-to-end with post-build health check + SCD2 audit

Wave order in `dag_silver_to_gold`:
1. Reference dims (parallel): dim_date, dim_time, dim_condition_category, dim_drug_class, dim_metric
2. dim_patient
3. Snowflaked entity dims: dim_condition, dim_medication, dim_device
4. Facts: fact_vital_reading, fact_vital_daily_summary, fact_lab_result, fact_prescription_fill, anomaly_detector

## Test plan
- [x] `airflow dags test pulsetrack_bronze_to_silver` — verify all tasks succeed
- [x] `airflow dags test pulsetrack_silver_to_gold` — verify 4-wave execution order
- [x] `airflow dags test pulsetrack_full_pipeline` — verify end-to-end run