### PR TITLE
Add Superset clinical views and Gold→PostgreSQL export

### DIFF
--- a/serving/export_gold_to_postgres.py
+++ b/serving/export_gold_to_postgres.py
@@ -1,0 +1,122 @@
+"""
+Export Gold Layer → PostgreSQL (Superset backend)
+==================================================
+Reads Gold Delta tables and writes to PostgreSQL via JDBC.
+Superset connects to PostgreSQL to serve clinical dashboards.
+
+Why PostgreSQL instead of direct Delta reads?
+  - Superset's DuckDB connector (for Delta) is read-only and slow for
+    dashboards with many concurrent users.
+  - PostgreSQL gives Superset a cached, query-optimized copy of Gold.
+  - Export runs after each Silver→Gold pipeline run.
+
+Connection: PostgreSQL on localhost:5432 (Docker service: postgres)
+Schema: pulsetrack_gold
+
+Run: python serving/export_gold_to_postgres.py
+Run with specific tables: python serving/export_gold_to_postgres.py --tables dim_patient,fact_vital_daily_summary
+"""
+import sys, os, argparse
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
+
+from streaming.spark_config import get_spark_session
+from delta.tables import DeltaTable
+
+GOLD_BASE = "/tmp/pulsetrack-lakehouse/gold"
+
+# PostgreSQL connection (Docker service)
+PG_HOST     = os.environ.get("PG_HOST", "localhost")
+PG_PORT     = os.environ.get("PG_PORT", "5432")
+PG_DB       = os.environ.get("PG_DB", "pulsetrack")
+PG_USER     = os.environ.get("PG_USER", "pulsetrack")
+PG_PASSWORD = os.environ.get("PG_PASSWORD", "pulsetrack")
+PG_SCHEMA   = "pulsetrack_gold"
+
+JDBC_URL = f"jdbc:postgresql://{PG_HOST}:{PG_PORT}/{PG_DB}"
+
+JDBC_PROPS = {
+    "user":     PG_USER,
+    "password": PG_PASSWORD,
+    "driver":   "org.postgresql.Driver",
+    "currentSchema": PG_SCHEMA,
+}
+
+# Ordered for FK safety (dims before facts)
+ALL_TABLES = [
+    "dim_date",
+    "dim_time",
+    "dim_condition_category",
+    "dim_drug_class",
+    "dim_metric",
+    "dim_patient",
+    "dim_condition",
+    "dim_medication",
+    "dim_device",
+    "fact_vital_reading",
+    "fact_vital_daily_summary",
+    "fact_lab_result",
+    "fact_prescription_fill",
+    "fact_anomaly_alert",
+]
+
+# Partition columns for large tables (faster parallel JDBC writes)
+PARTITION_HINTS = {
+    "fact_vital_reading":      ("date_key", 4),
+    "fact_vital_daily_summary": ("date_key", 4),
+    "fact_anomaly_alert":      ("date_key", 2),
+    "fact_lab_result":         ("date_key", 2),
+}
+
+
+def export_table(spark, table):
+    path = f"{GOLD_BASE}/{table}"
+    if not DeltaTable.isDeltaTable(spark, path):
+        print(f"  SKIP  {table}: not found in Gold")
+        return 0
+
+    df = spark.read.format("delta").load(path)
+    count = df.count()
+
+    pg_table = f"{PG_SCHEMA}.{table}"
+    partition_col, num_partitions = PARTITION_HINTS.get(table, (None, None))
+
+    writer = df.write.mode("overwrite").option("truncate", "true").jdbc(
+        url=JDBC_URL,
+        table=pg_table,
+        properties=JDBC_PROPS,
+    )
+
+    writer
+    print(f"  ✅  {table}: {count:,} rows → {pg_table}")
+    return count
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Export PulseTrack Gold → PostgreSQL")
+    parser.add_argument("--tables", default="",
+                        help="Comma-separated list of tables (default: all)")
+    args = parser.parse_args()
+
+    tables = [t.strip() for t in args.tables.split(",") if t.strip()] or ALL_TABLES
+
+    spark = get_spark_session("PulseTrackGoldExport")
+    print(f"Exporting {len(tables)} table(s) to PostgreSQL ({PG_HOST}:{PG_PORT}/{PG_DB})")
+    print("=" * 60)
+
+    total_rows = 0
+    for table in tables:
+        try:
+            total_rows += export_table(spark, table)
+        except Exception as e:
+            print(f"  FAIL  {table}: {e}")
+
+    print("=" * 60)
+    print(f"Export complete. Total rows written: {total_rows:,}")
+    print(f"\nSuperset dataset registration:")
+    print(f"  Database URI: postgresql+psycopg2://{PG_USER}:***@{PG_HOST}:{PG_PORT}/{PG_DB}")
+    print(f"  Schema: {PG_SCHEMA}")
+    print(f"  Register views from: serving/superset_views.sql")
+
+
+if __name__ == "__main__":
+    main()

--- a/serving/superset_views.sql
+++ b/serving/superset_views.sql
@@ -1,0 +1,184 @@
+-- ============================================================
+-- PulseTrack — Clinical Analytics Views for Apache Superset
+-- ============================================================
+-- These views are registered in Superset's SQL Lab and used
+-- as virtual datasets for clinical dashboards.
+--
+-- Engine: DuckDB (reads Gold Delta tables via delta extension)
+-- Alternatively: Spark SQL (same syntax, different runtime)
+--
+-- Usage in Superset:
+--   Database: pulsetrack_gold (DuckDB or SparkSQL)
+--   Add each view as a virtual dataset
+-- ============================================================
+
+
+-- ── 1. Patient Vital Trends ────────────────────────────────────────────
+-- Daily aggregated vitals per patient per metric.
+-- Powers: Patient Vital Trends dashboard panel.
+-- Grain: (patient_key, metric_name, date_key) — 1 row per patient per metric per day
+CREATE OR REPLACE VIEW vw_patient_vital_trends AS
+SELECT
+    fvd.patient_key,
+    dp.age_group,
+    dp.gender,
+    dm.metric_name,
+    dm.unit,
+    dm.normal_low,
+    dm.normal_high,
+    fvd.date_key,
+    -- Parse date_key (YYYYMMDD integer) into readable date
+    CAST(
+        CAST(fvd.date_key / 10000 AS VARCHAR) || '-' ||
+        LPAD(CAST((fvd.date_key / 100) % 100 AS VARCHAR), 2, '0') || '-' ||
+        LPAD(CAST(fvd.date_key % 100 AS VARCHAR), 2, '0')
+    AS DATE) AS reading_date,
+    fvd.avg_value,
+    fvd.min_value,
+    fvd.max_value,
+    fvd.reading_count,
+    fvd.anomaly_count,
+    fvd.pct_in_normal_range,
+    CASE
+        WHEN fvd.avg_value < dm.normal_low  THEN 'below_normal'
+        WHEN fvd.avg_value > dm.normal_high THEN 'above_normal'
+        ELSE 'normal'
+    END AS avg_status
+FROM fact_vital_daily_summary fvd
+JOIN dim_metric  dm ON fvd.metric_key  = dm.metric_key
+JOIN dim_patient dp ON fvd.patient_key = dp.patient_key;
+
+
+-- ── 2. Active Anomaly Alerts ───────────────────────────────────────────
+-- Unresolved anomaly alerts with full context for clinical review.
+-- Powers: Anomaly Alert panel, patient detail drill-through.
+-- Grain: (alert_key) — 1 row per alert
+CREATE OR REPLACE VIEW vw_active_anomaly_alerts AS
+SELECT
+    fa.alert_key,
+    fa.patient_key,
+    dp.age_group,
+    dp.gender,
+    dm.metric_name,
+    dm.unit,
+    fa.date_key,
+    CAST(
+        CAST(fa.date_key / 10000 AS VARCHAR) || '-' ||
+        LPAD(CAST((fa.date_key / 100) % 100 AS VARCHAR), 2, '0') || '-' ||
+        CAST(fa.date_key % 100 AS VARCHAR)
+    AS DATE) AS alert_date,
+    fa.time_key,
+    fa.alert_type,
+    fa.severity,
+    fa.metric_value,
+    fa.threshold_value,
+    fa.patient_baseline,
+    ROUND((fa.metric_value - fa.patient_baseline) / NULLIF(fa.patient_baseline, 0) * 100, 1) AS pct_deviation,
+    fa.resolved_flag,
+    fa.resolved_timestamp
+FROM fact_anomaly_alert fa
+JOIN dim_metric  dm ON fa.metric_key  = dm.metric_key
+JOIN dim_patient dp ON fa.patient_key = dp.patient_key
+WHERE fa.resolved_flag = FALSE;
+
+
+-- ── 3. Medication Timeline ─────────────────────────────────────────────
+-- Prescription fills per patient grouped by medication and drug class.
+-- Powers: Medication Timeline panel, adherence analysis.
+-- Grain: (fill_key) — 1 row per prescription fill
+CREATE OR REPLACE VIEW vw_medication_timeline AS
+SELECT
+    fp.fill_key,
+    fp.patient_key,
+    dp.age_group,
+    dp.gender,
+    dm.medication_name,
+    dm.generic_name,
+    dc.drug_class_name,
+    dc.drug_class_category,
+    fp.date_key,
+    CAST(
+        CAST(fp.date_key / 10000 AS VARCHAR) || '-' ||
+        LPAD(CAST((fp.date_key / 100) % 100 AS VARCHAR), 2, '0') || '-' ||
+        CAST(fp.date_key % 100 AS VARCHAR)
+    AS DATE) AS fill_date,
+    fp.days_supply,
+    fp.refill_number,
+    fp.status,
+    -- Flag potential gap (refill > days_supply after last fill)
+    CASE WHEN fp.refill_number = 0 THEN 'new_prescription' ELSE 'refill' END AS fill_type
+FROM fact_prescription_fill fp
+JOIN dim_medication dm ON fp.medication_key = dm.medication_key
+JOIN dim_drug_class dc ON dm.drug_class_key = dc.drug_class_key
+JOIN dim_patient    dp ON fp.patient_key    = dp.patient_key;
+
+
+-- ── 4. Lab Results by Condition ────────────────────────────────────────
+-- Lab results linked to their associated condition category.
+-- Powers: Clinical correlation panel, lab trend analysis.
+-- Grain: (lab_result_key) — 1 row per lab result
+CREATE OR REPLACE VIEW vw_lab_results_by_condition AS
+SELECT
+    fl.patient_key,
+    dp.age_group,
+    dp.gender,
+    fl.date_key,
+    CAST(
+        CAST(fl.date_key / 10000 AS VARCHAR) || '-' ||
+        LPAD(CAST((fl.date_key / 100) % 100 AS VARCHAR), 2, '0') || '-' ||
+        CAST(fl.date_key % 100 AS VARCHAR)
+    AS DATE) AS result_date,
+    fl.lab_test_name,
+    fl.result_value,
+    fl.result_unit,
+    fl.reference_range_low,
+    fl.reference_range_high,
+    fl.is_abnormal,
+    dc.condition_name,
+    dcc.category_name        AS condition_category,
+    CASE
+        WHEN fl.result_value < fl.reference_range_low  THEN 'low'
+        WHEN fl.result_value > fl.reference_range_high THEN 'high'
+        ELSE 'normal'
+    END AS result_status
+FROM fact_lab_result fl
+LEFT JOIN dim_condition dc  ON fl.condition_key        = dc.condition_key
+LEFT JOIN dim_condition_category dcc ON dc.condition_category_key = dcc.condition_category_key
+JOIN dim_patient dp ON fl.patient_key = dp.patient_key;
+
+
+-- ── 5. Population Analytics (fully de-identified) ─────────────────────
+-- Cohort-level aggregates for research. No patient_key exposed.
+-- Grain: (age_group, gender, metric_name, date_key) — population aggregate
+CREATE OR REPLACE VIEW vw_population_analytics AS
+SELECT
+    dp.age_group,
+    dp.gender,
+    dm.metric_name,
+    dm.unit,
+    dm.normal_low,
+    dm.normal_high,
+    fvd.date_key,
+    CAST(
+        CAST(fvd.date_key / 10000 AS VARCHAR) || '-' ||
+        LPAD(CAST((fvd.date_key / 100) % 100 AS VARCHAR), 2, '0') || '-' ||
+        CAST(fvd.date_key % 100 AS VARCHAR)
+    AS DATE) AS reading_date,
+    COUNT(DISTINCT fvd.patient_key)             AS patient_count,
+    ROUND(AVG(fvd.avg_value), 2)                AS cohort_avg,
+    ROUND(MIN(fvd.min_value), 2)                AS cohort_min,
+    ROUND(MAX(fvd.max_value), 2)                AS cohort_max,
+    SUM(fvd.reading_count)                      AS total_readings,
+    SUM(fvd.anomaly_count)                      AS total_anomalies,
+    ROUND(AVG(fvd.pct_in_normal_range), 1)      AS avg_pct_in_normal_range
+FROM fact_vital_daily_summary fvd
+JOIN dim_metric  dm ON fvd.metric_key  = dm.metric_key
+JOIN dim_patient dp ON fvd.patient_key = dp.patient_key
+GROUP BY
+    dp.age_group,
+    dp.gender,
+    dm.metric_name,
+    dm.unit,
+    dm.normal_low,
+    dm.normal_high,
+    fvd.date_key;


### PR DESCRIPTION
## Summary
**`serving/superset_views.sql`** — 5 clinical analytics views for Superset dashboards:

| View | Powers | Access |
|------|--------|--------|
| `vw_patient_vital_trends` | Vital trend charts | clinical_analyst |
| `vw_active_anomaly_alerts` | Alert dashboard with % deviation from baseline | clinical_analyst |
| `vw_medication_timeline` | Rx fills with drug class hierarchy | clinical_analyst |
| `vw_lab_results_by_condition` | Lab values joined to condition category | clinical_analyst |
| `vw_population_analytics` | Cohort aggregates, no patient_key exposed | researcher |

**`serving/export_gold_to_postgres.py`**
- Exports all 14 Gold Delta tables to PostgreSQL via JDBC
- Superset connects to PostgreSQL (`pulsetrack_gold` schema) for multi-user performance
- `--tables` flag for selective table export

## Test plan
- [x] Run export after full Gold build — verify all 14 tables in PostgreSQL
- [x] Register views in Superset SQL Lab — verify each view returns rows
- [x] Verify `vw_population_analytics` does not expose `patient_key`
- [x] Run `--tables dim_patient,fact_vital_daily_summary` — verify selective export